### PR TITLE
feat: add user related entities

### DIFF
--- a/lib/data/datasources/auth_remote_data_source.dart
+++ b/lib/data/datasources/auth_remote_data_source.dart
@@ -5,6 +5,9 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:http/http.dart' as http;
 import 'package:marketplace/domain/entities/user.dart';
+import 'package:marketplace/domain/entities/address.dart';
+import 'package:marketplace/domain/entities/bidded_product.dart';
+import 'package:marketplace/domain/entities/saved_product.dart';
 import 'package:flutter_facebook_auth/flutter_facebook_auth.dart';
 import 'package:flutter_line_sdk/flutter_line_sdk.dart';
 
@@ -168,6 +171,7 @@ class AuthRemoteDataSourceImpl implements AuthRemoteDataSource {
       id: json['id']?.toString() ?? '',
       name: json['name'] as String? ?? '',
       surname: json['surname'] as String? ?? '',
+      username: json['username'] as String? ?? '',
       email: json['email'] as String?,
       birthday: json['birthday'] as String?,
       gender: json['gender'] as String?,
@@ -179,6 +183,29 @@ class AuthRemoteDataSourceImpl implements AuthRemoteDataSource {
       phoneNumber:
           json['phone_number'] as String? ?? json['phoneNumber'] as String?,
       complete: complete,
+      savedProducts: (json['savedProducts'] as List<dynamic>? ?? [])
+          .map((e) => SavedProduct(
+                productId: e['productId']?.toString() ?? '',
+                currentBid: (e['currentBid'] as num?)?.toDouble() ?? 0,
+              ))
+          .toList(),
+      biddedProducts: (json['biddedProducts'] as List<dynamic>? ?? [])
+          .map((e) => BiddedProduct(
+                productId: e['productId']?.toString() ?? '',
+                currentBid: (e['currentBid'] as num?)?.toDouble() ?? 0,
+                yourBid: (e['yourBid'] as num?)?.toDouble() ?? 0,
+              ))
+          .toList(),
+      addresses: (json['addresses'] as List<dynamic>? ?? [])
+          .map((e) => Address(
+                address: e['address'] as String? ?? '',
+                subDistrict: e['subDistrict'] as String? ?? '',
+                district: e['district'] as String? ?? '',
+                province: e['province'] as String? ?? '',
+                postcode: e['postcode'] as String? ?? '',
+                isDefaultShipping: e['isDefaultShipping'] as bool? ?? false,
+              ))
+          .toList(),
     );
   }
 

--- a/lib/domain/entities/address.dart
+++ b/lib/domain/entities/address.dart
@@ -1,0 +1,30 @@
+import 'package:equatable/equatable.dart';
+
+class Address extends Equatable {
+  final String address;
+  final String subDistrict;
+  final String district;
+  final String province;
+  final String postcode;
+  final bool isDefaultShipping;
+
+  const Address({
+    required this.address,
+    required this.subDistrict,
+    required this.district,
+    required this.province,
+    required this.postcode,
+    this.isDefaultShipping = false,
+  });
+
+  @override
+  List<Object> get props => [
+        address,
+        subDistrict,
+        district,
+        province,
+        postcode,
+        isDefaultShipping,
+      ];
+}
+

--- a/lib/domain/entities/bidded_product.dart
+++ b/lib/domain/entities/bidded_product.dart
@@ -1,0 +1,17 @@
+import 'package:equatable/equatable.dart';
+
+class BiddedProduct extends Equatable {
+  final String productId;
+  final double currentBid;
+  final double yourBid;
+
+  const BiddedProduct({
+    required this.productId,
+    required this.currentBid,
+    required this.yourBid,
+  });
+
+  @override
+  List<Object> get props => [productId, currentBid, yourBid];
+}
+

--- a/lib/domain/entities/saved_product.dart
+++ b/lib/domain/entities/saved_product.dart
@@ -1,0 +1,15 @@
+import 'package:equatable/equatable.dart';
+
+class SavedProduct extends Equatable {
+  final String productId;
+  final double currentBid;
+
+  const SavedProduct({
+    required this.productId,
+    required this.currentBid,
+  });
+
+  @override
+  List<Object> get props => [productId, currentBid];
+}
+

--- a/lib/domain/entities/user.dart
+++ b/lib/domain/entities/user.dart
@@ -1,9 +1,13 @@
 import 'package:equatable/equatable.dart';
+import 'address.dart';
+import 'bidded_product.dart';
+import 'saved_product.dart';
 
 class User extends Equatable {
   final String id;
   final String name;
   final String surname;
+  final String username;
   final String? birthday;
   final String? email;
   final String? gender;
@@ -13,11 +17,15 @@ class User extends Equatable {
   final String? province;
   final String? phoneNumber;
   final bool complete;
+  final List<SavedProduct> savedProducts;
+  final List<BiddedProduct> biddedProducts;
+  final List<Address> addresses;
 
   const User({
     required this.id,
     required this.name,
     required this.surname,
+    required this.username,
     this.email,
     this.birthday,
     this.gender,
@@ -27,6 +35,9 @@ class User extends Equatable {
     this.province,
     this.phoneNumber,
     this.complete = false,
+    this.savedProducts = const [],
+    this.biddedProducts = const [],
+    this.addresses = const [],
   });
 
   @override
@@ -34,6 +45,7 @@ class User extends Equatable {
         id,
         name,
         surname,
+        username,
         birthday,
         gender,
         address,
@@ -41,6 +53,9 @@ class User extends Equatable {
         district,
         province,
         phoneNumber,
-        complete
+        complete,
+        savedProducts,
+        biddedProducts,
+        addresses
       ];
 }


### PR DESCRIPTION
## Summary
- add SavedProduct, BiddedProduct and Address entities
- extend User model with username, saved/bidded products and addresses
- parse new user fields from auth remote data source

## Testing
- `dart format lib/domain/entities/saved_product.dart lib/domain/entities/bidded_product.dart lib/domain/entities/address.dart lib/domain/entities/user.dart lib/data/datasources/auth_remote_data_source.dart` *(fails: command not found)*
- `dart test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5798b08bc832783189302d29992fd